### PR TITLE
Implement minimal VPN Telegram bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o vpn-bot ./cmd/bot
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /app/vpn-bot ./vpn-bot
+COPY migrations ./migrations
+ENV TELEGRAM_TOKEN="" \
+    ADMIN_IDS="" \
+    PANEL_URL="" \
+    PANEL_TOKEN="" \
+    DB_DSN=""
+CMD ["./vpn-bot"]

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"vpn-bot/internal/bot"
+	"vpn-bot/internal/config"
+	"vpn-bot/internal/panel"
+	"vpn-bot/internal/scheduler"
+	"vpn-bot/internal/storage"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	db, err := storage.Open(cfg.DBDSN)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	store := storage.New(db)
+	panelClient := panel.New(cfg.PanelURL, cfg.PanelToken)
+
+	api, err := tgbotapi.NewBotAPI(cfg.TelegramToken)
+	if err != nil {
+		log.Fatalf("new bot: %v", err)
+	}
+
+	b := bot.New(api, store, panelClient, cfg.AdminIDs)
+
+	sched := scheduler.New()
+	if err := sched.ScheduleDailyNotifications(b); err != nil {
+		log.Fatalf("schedule notifications: %v", err)
+	}
+	sched.Start()
+	defer sched.Stop()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := b.Run(ctx); err != nil && err != context.Canceled {
+		log.Printf("bot stopped: %v", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: vpn
+      POSTGRES_PASSWORD: vpn
+      POSTGRES_DB: vpn
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  bot:
+    build: .
+    depends_on:
+      - db
+    environment:
+      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN}
+      ADMIN_IDS: ${ADMIN_IDS}
+      PANEL_URL: ${PANEL_URL}
+      PANEL_TOKEN: ${PANEL_TOKEN}
+      DB_DSN: postgres://vpn:vpn@db:5432/vpn?sslmode=disable
+
+volumes:
+  db_data:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module vpn-bot
+
+go 1.21
+
+require (
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+github.com/jackc/pgx/v5 v5.5.4
+github.com/robfig/cron/v3 v3.0.1
+)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,0 +1,325 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"vpn-bot/internal/panel"
+	"vpn-bot/internal/storage"
+)
+
+type Bot struct {
+	api             *tgbotapi.BotAPI
+	store           *storage.Storage
+	panel           *panel.Client
+	admins          map[int64]struct{}
+	awaitingComment map[int64]int
+	mu              sync.Mutex
+}
+
+func New(api *tgbotapi.BotAPI, store *storage.Storage, panel *panel.Client, adminIDs []int64) *Bot {
+	admins := make(map[int64]struct{})
+	for _, id := range adminIDs {
+		admins[id] = struct{}{}
+	}
+	return &Bot{
+		api:             api,
+		store:           store,
+		panel:           panel,
+		admins:          admins,
+		awaitingComment: make(map[int64]int),
+	}
+}
+
+func (b *Bot) Run(ctx context.Context) error {
+	updateConfig := tgbotapi.NewUpdate(0)
+	updateConfig.Timeout = 30
+	updates := b.api.GetUpdatesChan(updateConfig)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case update := <-updates:
+			b.handleUpdate(ctx, update)
+		}
+	}
+}
+
+func (b *Bot) handleUpdate(ctx context.Context, update tgbotapi.Update) {
+	if update.Message != nil {
+		msg := update.Message
+		switch {
+		case msg.IsCommand():
+			b.handleCommand(ctx, msg)
+		case msg.Photo != nil:
+			b.handlePhoto(ctx, msg)
+		default:
+			b.handleText(ctx, msg)
+		}
+	}
+
+	if update.CallbackQuery != nil {
+		b.handleCallback(ctx, update.CallbackQuery)
+	}
+}
+
+func (b *Bot) handleCommand(ctx context.Context, msg *tgbotapi.Message) {
+	switch msg.Command() {
+	case "start":
+		b.handleStart(ctx, msg)
+	case "getkey":
+		b.handleGetKey(ctx, msg)
+	case "status":
+		b.handleStatus(ctx, msg)
+	case "help":
+		b.handleHelp(msg.Chat.ID)
+	default:
+		b.reply(msg.Chat.ID, "Неизвестная команда. Используйте /help")
+	}
+}
+
+func (b *Bot) handleStart(ctx context.Context, msg *tgbotapi.Message) {
+	username := msg.From.UserName
+	if username == "" {
+		username = msg.From.FirstName
+	}
+	user, err := b.store.UpsertUser(ctx, msg.From.ID, username)
+	if err != nil {
+		log.Printf("upsert user: %v", err)
+		b.reply(msg.Chat.ID, "Не удалось зарегистрироваться. Попробуйте позже")
+		return
+	}
+	text := fmt.Sprintf("Вы зарегистрированы! Ваш ID в системе: %d", user.ID)
+	b.reply(msg.Chat.ID, text)
+}
+
+func (b *Bot) handleGetKey(ctx context.Context, msg *tgbotapi.Message) {
+	user, err := b.store.GetUserByTelegramID(ctx, msg.From.ID)
+	if err != nil || user == nil {
+		b.reply(msg.Chat.ID, "Сначала выполните /start")
+		return
+	}
+	key, err := b.panel.AddClient(ctx, user.ID)
+	if err != nil {
+		log.Printf("panel add client: %v", err)
+		b.reply(msg.Chat.ID, "Не удалось создать ключ. Попробуйте позже")
+		return
+	}
+	expires := time.Now().Add(30 * 24 * time.Hour)
+	if err := b.store.UpdateUserKey(ctx, user.ID, key, expires); err != nil {
+		log.Printf("update user key: %v", err)
+	}
+	b.reply(msg.Chat.ID, fmt.Sprintf("Ваш новый ключ: %s\nДействителен до %s", key, expires.Format("02.01.2006")))
+}
+
+func (b *Bot) handleStatus(ctx context.Context, msg *tgbotapi.Message) {
+	user, err := b.store.GetUserByTelegramID(ctx, msg.From.ID)
+	if err != nil || user == nil || !user.KeyID.Valid {
+		b.reply(msg.Chat.ID, "Ключ не найден. Запросите новый через /getkey")
+		return
+	}
+
+	expires, err := b.panel.GetClientStatus(ctx, user.KeyID.String)
+	if err != nil {
+		log.Printf("panel get status: %v", err)
+		b.reply(msg.Chat.ID, "Не удалось получить статус. Попробуйте позже")
+		return
+	}
+	b.reply(msg.Chat.ID, fmt.Sprintf("Ключ активен до %s", expires.Format("02.01.2006")))
+}
+
+func (b *Bot) handleHelp(chatID int64) {
+	helpText := "Инструкция по установке Xray/VLESS:\n" +
+		"iOS: используйте приложение Shadowrocket или Streisand.\n" +
+		"Android: V2rayNG или Nekobox.\n" +
+		"Windows: V2RayN.\n" +
+		"Linux/macOS: Xray-core через терминал."
+	b.reply(chatID, helpText)
+}
+
+func (b *Bot) handlePhoto(ctx context.Context, msg *tgbotapi.Message) {
+	user, err := b.store.GetUserByTelegramID(ctx, msg.From.ID)
+	if err != nil || user == nil {
+		b.reply(msg.Chat.ID, "Сначала выполните /start")
+		return
+	}
+	if len(msg.Photo) == 0 {
+		return
+	}
+	photo := msg.Photo[len(msg.Photo)-1]
+	payment, err := b.store.CreatePayment(ctx, user.ID, photo.FileID)
+	if err != nil {
+		log.Printf("create payment: %v", err)
+		b.reply(msg.Chat.ID, "Не удалось сохранить оплату")
+		return
+	}
+
+	caption := fmt.Sprintf("Новый платеж от @%s (ID %d)", msg.From.UserName, user.ID)
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		[]tgbotapi.InlineKeyboardButton{
+			tgbotapi.NewInlineKeyboardButtonData("✅ Подтвердить", fmt.Sprintf("confirm:%d", payment.ID)),
+			tgbotapi.NewInlineKeyboardButtonData("❌ Отклонить", fmt.Sprintf("reject:%d", payment.ID)),
+		},
+	)
+
+	for adminID := range b.admins {
+		photoMsg := tgbotapi.NewPhoto(adminID, tgbotapi.FileID(photo.FileID))
+		photoMsg.Caption = caption
+		photoMsg.ReplyMarkup = keyboard
+		if _, err := b.api.Send(photoMsg); err != nil {
+			log.Printf("send admin photo: %v", err)
+		}
+	}
+
+	b.reply(msg.Chat.ID, "Платеж отправлен на проверку")
+}
+
+func (b *Bot) handleText(ctx context.Context, msg *tgbotapi.Message) {
+	if !b.isAdmin(msg.From.ID) {
+		return
+	}
+
+	b.mu.Lock()
+	paymentID, waiting := b.awaitingComment[msg.From.ID]
+	if waiting {
+		delete(b.awaitingComment, msg.From.ID)
+	}
+	b.mu.Unlock()
+
+	if !waiting {
+		return
+	}
+
+	comment := msg.Text
+	if err := b.store.UpdatePaymentStatus(ctx, paymentID, "rejected", &comment); err != nil {
+		log.Printf("update payment status: %v", err)
+	}
+
+	payment, err := b.store.GetPayment(ctx, paymentID)
+	if err != nil {
+		log.Printf("get payment: %v", err)
+		return
+	}
+
+	user, err := b.store.GetUserByID(ctx, payment.UserID)
+	if err != nil {
+		log.Printf("get user by id: %v", err)
+		return
+	}
+
+	b.reply(user.TelegramID, fmt.Sprintf("Оплата отклонена: %s", comment))
+	b.reply(msg.Chat.ID, "Комментарий отправлен пользователю")
+}
+
+func (b *Bot) handleCallback(ctx context.Context, callback *tgbotapi.CallbackQuery) {
+	if !b.isAdmin(callback.From.ID) {
+		return
+	}
+	data := callback.Data
+	parts := strings.Split(data, ":")
+	if len(parts) != 2 {
+		return
+	}
+	action := parts[0]
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return
+	}
+
+	switch action {
+	case "confirm":
+		b.confirmPayment(ctx, callback, id)
+	case "reject":
+		b.requestRejectReason(callback, id)
+	}
+
+	_, _ = b.api.Request(tgbotapi.NewCallback(callback.ID, ""))
+}
+
+func (b *Bot) confirmPayment(ctx context.Context, callback *tgbotapi.CallbackQuery, paymentID int) {
+	payment, err := b.store.GetPayment(ctx, paymentID)
+	if err != nil {
+		log.Printf("get payment: %v", err)
+		return
+	}
+
+	user, err := b.store.GetUserByID(ctx, payment.UserID)
+	if err != nil {
+		log.Printf("get user: %v", err)
+		return
+	}
+
+	if !user.KeyID.Valid {
+		b.reply(user.TelegramID, "У вас нет активного ключа. Запросите /getkey")
+		return
+	}
+
+	expires := time.Now().Add(30 * 24 * time.Hour)
+	if err := b.panel.UpdateClient(ctx, user.KeyID.String, 30); err != nil {
+		log.Printf("panel update: %v", err)
+		b.reply(user.TelegramID, "Не удалось продлить подписку. Свяжитесь с админом")
+		return
+	}
+
+	if err := b.store.UpdateUserKey(ctx, user.ID, user.KeyID.String, expires); err != nil {
+		log.Printf("update user key: %v", err)
+	}
+
+	if err := b.store.UpdatePaymentStatus(ctx, paymentID, "confirmed", nil); err != nil {
+		log.Printf("update payment status: %v", err)
+	}
+
+	b.reply(user.TelegramID, fmt.Sprintf("Оплата подтверждена! Новый срок: %s", expires.Format("02.01.2006")))
+	b.editCallback(callback, "Оплата подтверждена")
+}
+
+func (b *Bot) requestRejectReason(callback *tgbotapi.CallbackQuery, paymentID int) {
+	b.mu.Lock()
+	b.awaitingComment[callback.From.ID] = paymentID
+	b.mu.Unlock()
+	b.editCallback(callback, "Отправьте причину отказа сообщением")
+}
+
+func (b *Bot) editCallback(callback *tgbotapi.CallbackQuery, text string) {
+	msg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, text)
+	if _, err := b.api.Send(msg); err != nil {
+		log.Printf("edit message: %v", err)
+	}
+}
+
+func (b *Bot) reply(chatID int64, text string) {
+	msg := tgbotapi.NewMessage(chatID, text)
+	if _, err := b.api.Send(msg); err != nil {
+		log.Printf("send message: %v", err)
+	}
+}
+
+func (b *Bot) isAdmin(id int64) bool {
+	_, ok := b.admins[id]
+	return ok
+}
+
+func (b *Bot) NotifyRenewal(ctx context.Context, when time.Time) error {
+	from := when
+	to := when.Add(24 * time.Hour)
+	users, err := b.store.ListUsersExpiringBetween(ctx, from, to)
+	if err != nil {
+		return err
+	}
+	for _, user := range users {
+		if !user.ExpiresAt.Valid {
+			continue
+		}
+		text := fmt.Sprintf("Напоминание об оплате. Срок действия до %s", user.ExpiresAt.Time.Format("02.01.2006"))
+		b.reply(user.TelegramID, text)
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Config struct {
+	TelegramToken string
+	AdminIDs      []int64
+	PanelURL      string
+	PanelToken    string
+	DBDSN         string
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{}
+
+	cfg.TelegramToken = os.Getenv("TELEGRAM_TOKEN")
+	if cfg.TelegramToken == "" {
+		return nil, fmt.Errorf("TELEGRAM_TOKEN is required")
+	}
+
+	admins := os.Getenv("ADMIN_IDS")
+	if admins != "" {
+		parts := strings.Split(admins, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			id, err := parseInt64(part)
+			if err != nil {
+				return nil, fmt.Errorf("invalid admin id %q: %w", part, err)
+			}
+			cfg.AdminIDs = append(cfg.AdminIDs, id)
+		}
+	}
+
+	cfg.PanelURL = os.Getenv("PANEL_URL")
+	if cfg.PanelURL == "" {
+		return nil, fmt.Errorf("PANEL_URL is required")
+	}
+
+	cfg.PanelToken = os.Getenv("PANEL_TOKEN")
+	if cfg.PanelToken == "" {
+		return nil, fmt.Errorf("PANEL_TOKEN is required")
+	}
+
+	cfg.DBDSN = os.Getenv("DB_DSN")
+	if cfg.DBDSN == "" {
+		return nil, fmt.Errorf("DB_DSN is required")
+	}
+
+	return cfg, nil
+}
+
+func parseInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
+}

--- a/internal/panel/client.go
+++ b/internal/panel/client.go
@@ -1,0 +1,149 @@
+package panel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+type AddClientRequest struct {
+	ID      int    `json:"id"`
+	Email   string `json:"email"`
+	LimitIP int    `json:"limitIp"`
+	TotalGB int    `json:"totalGB"`
+	Expiry  int64  `json:"expiryTime"`
+	Enable  bool   `json:"enable"`
+}
+
+type AddClientResponse struct {
+	Success bool   `json:"success"`
+	Msg     string `json:"msg"`
+	Obj     struct {
+		ID string `json:"id"`
+	} `json:"obj"`
+}
+
+type UpdateClientRequest struct {
+	ID        string `json:"id"`
+	Expiry    int64  `json:"expiryTime"`
+	Operation string `json:"operation"`
+}
+
+type GenericResponse struct {
+	Success bool   `json:"success"`
+	Msg     string `json:"msg"`
+}
+
+type TrafficResponse struct {
+	Success bool   `json:"success"`
+	Msg     string `json:"msg"`
+	Obj     []struct {
+		ID     string `json:"id"`
+		Expiry int64  `json:"expiryTime"`
+		Enable bool   `json:"enable"`
+	} `json:"obj"`
+}
+
+func New(baseURL, token string) *Client {
+	return &Client{
+		baseURL:    baseURL,
+		token:      token,
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) AddClient(ctx context.Context, userID int) (string, error) {
+	reqBody := AddClientRequest{
+		ID:      userID,
+		Email:   fmt.Sprintf("user-%d@example.com", userID),
+		LimitIP: 1,
+		TotalGB: 0,
+		Expiry:  time.Now().Add(30 * 24 * time.Hour).Unix(),
+		Enable:  true,
+	}
+	var resp AddClientResponse
+	if err := c.do(ctx, http.MethodPost, "xui/inbound/addClient", reqBody, &resp); err != nil {
+		return "", err
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("panel error: %s", resp.Msg)
+	}
+	return resp.Obj.ID, nil
+}
+
+func (c *Client) UpdateClient(ctx context.Context, keyID string, days int) error {
+	reqBody := UpdateClientRequest{
+		ID:        keyID,
+		Expiry:    time.Now().Add(time.Duration(days) * 24 * time.Hour).Unix(),
+		Operation: "update",
+	}
+	return c.postGeneric(ctx, "xui/inbound/updateClient", reqBody)
+}
+
+func (c *Client) DelClient(ctx context.Context, keyID string) error {
+	body := map[string]string{"id": keyID}
+	return c.postGeneric(ctx, "xui/inbound/delClient", body)
+}
+
+func (c *Client) GetClientStatus(ctx context.Context, keyID string) (time.Time, error) {
+	var resp TrafficResponse
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("xui/inbound/getClientTraffics?id=%s", keyID), nil, &resp); err != nil {
+		return time.Time{}, err
+	}
+	if !resp.Success || len(resp.Obj) == 0 {
+		return time.Time{}, fmt.Errorf("client not found: %s", resp.Msg)
+	}
+	return time.Unix(resp.Obj[0].Expiry, 0), nil
+}
+
+func (c *Client) postGeneric(ctx context.Context, path string, body interface{}) error {
+	var resp GenericResponse
+	if err := c.do(ctx, http.MethodPost, path, body, &resp); err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("panel error: %s", resp.Msg)
+	}
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body interface{}, dest interface{}) error {
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("panel request failed: %s", resp.Status)
+	}
+
+	if dest != nil {
+		return json.NewDecoder(resp.Body).Decode(dest)
+	}
+	return nil
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,39 @@
+package scheduler
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+type Notifier interface {
+	NotifyRenewal(ctx context.Context, when time.Time) error
+}
+
+type Scheduler struct {
+	cron *cron.Cron
+}
+
+func New() *Scheduler {
+	return &Scheduler{cron: cron.New()}
+}
+
+func (s *Scheduler) Start() {
+	s.cron.Start()
+}
+
+func (s *Scheduler) Stop() {
+	s.cron.Stop()
+}
+
+func (s *Scheduler) ScheduleDailyNotifications(n Notifier) error {
+	_, err := s.cron.AddFunc("0 9 * * *", func() {
+		ctx := context.Background()
+		if err := n.NotifyRenewal(ctx, time.Now()); err != nil {
+			log.Printf("notify renewal: %v", err)
+		}
+	})
+	return err
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+type Storage struct {
+	db *sql.DB
+}
+
+type User struct {
+	ID         int
+	TelegramID int64
+	Username   sql.NullString
+	KeyID      sql.NullString
+	ExpiresAt  sql.NullTime
+	Status     string
+}
+
+type Payment struct {
+	ID            int
+	UserID        int
+	ScreenshotURL string
+	Status        string
+	Comment       sql.NullString
+	CreatedAt     time.Time
+}
+
+func New(db *sql.DB) *Storage {
+	return &Storage{db: db}
+}
+
+func Open(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, db.Ping()
+}
+
+func (s *Storage) UpsertUser(ctx context.Context, telegramID int64, username string) (*User, error) {
+	query := `INSERT INTO users (telegram_id, username)
+VALUES ($1, $2)
+ON CONFLICT (telegram_id) DO UPDATE SET username = EXCLUDED.username
+RETURNING id, telegram_id, username, key_id, expires_at, status`
+	row := s.db.QueryRowContext(ctx, query, telegramID, username)
+	var u User
+	if err := row.Scan(&u.ID, &u.TelegramID, &u.Username, &u.KeyID, &u.ExpiresAt, &u.Status); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (s *Storage) GetUserByTelegramID(ctx context.Context, telegramID int64) (*User, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, telegram_id, username, key_id, expires_at, status FROM users WHERE telegram_id=$1`, telegramID)
+	var u User
+	if err := row.Scan(&u.ID, &u.TelegramID, &u.Username, &u.KeyID, &u.ExpiresAt, &u.Status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (s *Storage) GetUserByID(ctx context.Context, id int) (*User, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, telegram_id, username, key_id, expires_at, status FROM users WHERE id=$1`, id)
+	var u User
+	if err := row.Scan(&u.ID, &u.TelegramID, &u.Username, &u.KeyID, &u.ExpiresAt, &u.Status); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (s *Storage) UpdateUserKey(ctx context.Context, userID int, keyID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET key_id=$1, expires_at=$2 WHERE id=$3`, keyID, expiresAt, userID)
+	return err
+}
+
+func (s *Storage) UpdateUserStatus(ctx context.Context, userID int, status string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET status=$1 WHERE id=$2`, status, userID)
+	return err
+}
+
+func (s *Storage) CreatePayment(ctx context.Context, userID int, screenshotURL string) (*Payment, error) {
+	query := `INSERT INTO payments (user_id, screenshot_url) VALUES ($1, $2) RETURNING id, user_id, screenshot_url, status, comment, created_at`
+	row := s.db.QueryRowContext(ctx, query, userID, screenshotURL)
+	var p Payment
+	if err := row.Scan(&p.ID, &p.UserID, &p.ScreenshotURL, &p.Status, &p.Comment, &p.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *Storage) UpdatePaymentStatus(ctx context.Context, paymentID int, status string, comment *string) error {
+	if comment != nil {
+		_, err := s.db.ExecContext(ctx, `UPDATE payments SET status=$1, comment=$2 WHERE id=$3`, status, *comment, paymentID)
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE payments SET status=$1 WHERE id=$2`, status, paymentID)
+	return err
+}
+
+func (s *Storage) GetPayment(ctx context.Context, paymentID int) (*Payment, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, user_id, screenshot_url, status, comment, created_at FROM payments WHERE id=$1`, paymentID)
+	var p Payment
+	if err := row.Scan(&p.ID, &p.UserID, &p.ScreenshotURL, &p.Status, &p.Comment, &p.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *Storage) ListUsersExpiringBetween(ctx context.Context, from, to time.Time) ([]User, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, telegram_id, username, key_id, expires_at, status FROM users WHERE expires_at BETWEEN $1 AND $2`, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.TelegramID, &u.Username, &u.KeyID, &u.ExpiresAt, &u.Status); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    telegram_id BIGINT UNIQUE,
+    username TEXT,
+    key_id TEXT,
+    expires_at TIMESTAMP,
+    status TEXT DEFAULT 'active'
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id SERIAL PRIMARY KEY,
+    user_id INT REFERENCES users(id),
+    screenshot_url TEXT,
+    status TEXT DEFAULT 'pending',
+    comment TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add a Telegram bot that registers users, issues keys, and routes payment approvals through inline callbacks
- wire up storage, panel client, scheduler, and configuration helpers together with SQL migrations
- provide containerization via Dockerfile and docker-compose stack for the bot and PostgreSQL

## Testing
- `go build ./...` *(fails in the offline execution environment when trying to download module proxies)*

------
https://chatgpt.com/codex/tasks/task_e_68d072db7f3083329231d607c3d1df14